### PR TITLE
Updated Rubocop to `~> 0.52.1`

### DIFF
--- a/kramdown_rpf.gemspec
+++ b/kramdown_rpf.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'kramdown', '~> 1.2', '>= 1.2.0'
 
-  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~>  0.44'
+  spec.add_development_dependency 'rubocop', '~> 0.52.1'
 end


### PR DESCRIPTION
Github has alerted us to a vulnerability in our current version of Rubocop. This PR updates to the latest release.