### PR TITLE
Added separate classNames for hints and ingredient

### DIFF
--- a/examples/collapse.html
+++ b/examples/collapse.html
@@ -1,4 +1,4 @@
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--ingredient">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     Downloading and installing the Raspberry Pi software
   </h3>

--- a/examples/collapse_in_challenge.html
+++ b/examples/collapse_in_challenge.html
@@ -22,7 +22,7 @@
   </li>
 </ol>
 
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--hints">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     I need a hint
   </h3>
@@ -68,7 +68,7 @@
 
   <p>Every time a new intruder triggers the motion sensor the video will be overwritten. If you have lots of pesky parents or brothers and sisters intruding into your room, you want to keep videos of all of them. Can you write some code to automatically find out the current date and time and add it to the video filename so that each video we take will have a different filename?</p>
 
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--ingredient">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     Getting the date and time in Python
   </h3>

--- a/examples/collapse_music_box.html
+++ b/examples/collapse_music_box.html
@@ -1,4 +1,4 @@
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--ingredient">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     Creating Directories on a Raspberry Pi
   </h3>

--- a/examples/collapse_with_space.html
+++ b/examples/collapse_with_space.html
@@ -6,7 +6,7 @@
   <li>
     <p>Open IDLE, create a new file and save it as <strong>parent-detector.py</strong></p>
 
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--ingredient">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     Opening IDLE
   </h3>

--- a/examples/hints.html
+++ b/examples/hints.html
@@ -1,4 +1,4 @@
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--hints">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     I need a hint
   </h3>

--- a/examples/task_with_hints.html
+++ b/examples/task_with_hints.html
@@ -9,7 +9,7 @@
 
 <p>You can access the direction the joystick was moved in with the help of the event parameter: use the command <code>event.direction</code>.</p>
 
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--hints">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     I need a hint
   </h3>

--- a/examples/task_with_ingredient.html
+++ b/examples/task_with_ingredient.html
@@ -9,7 +9,7 @@
 
 <p>You can access the direction the joystick was moved in with the help of the event parameter: use the command <code>event.direction</code>.</p>
 
-<div class="c-project-panel">
+<div class="c-project-panel c-project-panel--ingredient">
   <h3 class="c-project-panel__heading js-project-panel__toggle">
     Downloading and installing the Raspberry Pi software
   </h3>

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -23,7 +23,7 @@ module RPF
           KRAMDOWN_OPTIONS
         ).to_html
         <<~HEREDOC
-          <div class="c-project-panel">
+          <div class="c-project-panel c-project-panel--ingredient">
             <h3 class="c-project-panel__heading js-project-panel__toggle">
               #{title}
             </h3>
@@ -53,7 +53,7 @@ module RPF
           coderay_css: :class, coderay_line_numbers: nil, parse_block_html: true, input: 'KramdownRPF'
         ).to_html
         <<~HEREDOC
-          <div class="c-project-panel">
+          <div class="c-project-panel c-project-panel--hints">
             <h3 class="c-project-panel__heading js-project-panel__toggle">
               I need a hint
             </h3>


### PR DESCRIPTION
Closes #4 

* `convert_hints_to_html` now generates `.c-project-panel.c-project-panel--hints`
* `convert_collapse_to_html` now generates `.c-project-panel.c-project-panel--ingredient`

I was unsure about whether or not gthe className for the ingredient should be `c-project-panel--collapse` for consistency. But then thought that might be ambiguous on slash-learning-ui, because both kinds of panels collapse. Went with `c-project-panel--ingredient` in the end, but happy to discuss using collapse instead.