### PR TITLE
Set locale load_path absolutely

### DIFF
--- a/lib/kramdown_rpf.rb
+++ b/lib/kramdown_rpf.rb
@@ -4,6 +4,5 @@ require 'kramdown'
 require_relative 'kramdown_rpf/version'
 require_relative 'kramdown_rpf/kramdown'
 
-I18n.load_path = Dir[File.join('locales', '*.yml')]
+I18n.load_path = Dir[File.join(File.absolute_path('../..', __FILE__), 'locales', '*.yml')]
 I18n.backend.load_translations
-


### PR DESCRIPTION
It was set relatively before, which changed when the gem was required in ups & no locales were loaded.

references https://github.com/RaspberryPiFoundation/ups/issues/675
closes #10