### PR TITLE
Add locales to `I18n.load_path` rather than resetting it

### DIFF
--- a/lib/kramdown_rpf.rb
+++ b/lib/kramdown_rpf.rb
@@ -4,5 +4,5 @@ require 'kramdown'
 require_relative 'kramdown_rpf/version'
 require_relative 'kramdown_rpf/kramdown'
 
-I18n.load_path = Dir[File.join(File.absolute_path('../..', __FILE__), 'locales', '*.yml')]
+I18n.load_path << Dir[File.join(File.absolute_path('../..', __FILE__), 'locales', '*.yml')]
 I18n.backend.load_translations


### PR DESCRIPTION
Using `=` removed any other translations from I18n.

All tests in `ups` now pass, rather than the hint specific tests.

This i18n stuff is harder than you'd think 😢 