### PR TITLE
Allow trailing whitespace after YAML deliminators 4aa9d59

### DIFF
--- a/examples/collapse/collapse_with_space.md
+++ b/examples/collapse/collapse_with_space.md
@@ -5,7 +5,7 @@ We're going to write some code to print out `Motion detected!` when the PIR sens
 1. Open IDLE, create a new file and save it as **parent-detector.py**
 
     --- collapse ---
-    ---
+    ---  
     title: Opening IDLE
     image: images/idle.png
     ---

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -1,7 +1,7 @@
 module RPF
   module Plugin
     module Kramdown
-      YAML_FRONT_MATTER_REGEXP = /\n\s*---\n(.*?)---(.*)/m
+      YAML_FRONT_MATTER_REGEXP = /\n\s*---\s*\n(.*?)---(.*)/m
       KRAMDOWN_OPTIONS = {
         input:              'KramdownRPF',
         parse_block_html:   true,


### PR DESCRIPTION
A YAML deliminator: 
```
--- 
title: Blah
---
```

With trailing whitespace after the `---` was failing to match the Regexp. 