### PR TITLE
Added tests to confirm scratch2 and 3 support

### DIFF
--- a/examples/scratch/scratch2.html
+++ b/examples/scratch/scratch2.html
@@ -1,0 +1,8 @@
+<pre><code class="language-blocks">when flag clicked
+repeat (10)
+  change y by (10)
+end
+repeat (10)
+  change y by (-10)
+end
+</code></pre>

--- a/examples/scratch/scratch2.md
+++ b/examples/scratch/scratch2.md
@@ -1,0 +1,9 @@
+```blocks
+when flag clicked
+repeat (10)
+  change y by (10)
+end
+repeat (10)
+  change y by (-10)
+end
+```

--- a/examples/scratch/scratch3.html
+++ b/examples/scratch/scratch3.html
@@ -1,0 +1,8 @@
+<pre><code class="language-blocks3">when flag clicked
+repeat (10)
+  change y by (10)
+end
+repeat (10)
+  change y by (-10)
+end
+</code></pre>

--- a/examples/scratch/scratch3.md
+++ b/examples/scratch/scratch3.md
@@ -1,0 +1,9 @@
+```blocks3
+when flag clicked
+repeat (10)
+  change y by (10)
+end
+repeat (10)
+  change y by (-10)
+end
+```

--- a/lib/kramdown_rpf/version.rb
+++ b/lib/kramdown_rpf/version.rb
@@ -1,3 +1,3 @@
 module KramdownRPF
-  VERSION = '0.7.6'.freeze
+  VERSION = '0.8.0'.freeze
 end

--- a/spec/kramdown_rpf_spec.rb
+++ b/spec/kramdown_rpf_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe KramdownRPF do
     no_print/no_print
     print_only/print_only
     save/save
+    scratch/scratch2
+    scratch/scratch3
     task/task
     task/task_with_hints
     task/task_with_ingredient


### PR DESCRIPTION
This doesn't really enable Scratch3 support, but it allows to us to start using the new `blocks3` syntax with confidence.