### PR TITLE
Provide a function for detecting leftover markup

### DIFF
--- a/examples/errors/collapse.md
+++ b/examples/errors/collapse.md
@@ -1,0 +1,6 @@
+--- collapse ---
+---
+title: Downloading and installing the Raspberry Pi software
+---
+
+Content here comes from the ingredient.

--- a/lib/kramdown_rpf/kramdown.rb
+++ b/lib/kramdown_rpf/kramdown.rb
@@ -155,6 +155,17 @@ module Kramdown
 
   module Parser
     class KramdownRPF < ::Kramdown::Parser::GFM
+
+      KEYWORDS = [
+        'challenge',
+        'code',
+        'collapse',
+        'hints',
+        'no-print',
+        'print-only',
+        'save',
+        'task']
+
       CHALLENGE_PATTERN  = %r{^#{OPT_SPACE}---[ \t]*challenge[ \t]*---(.*?)---[ \t]*\/challenge[ \t]*---}m
       CODE_PATTERN       = %r{^#{OPT_SPACE}---[ \t]*code[ \t]*---(.*?)---[ \t]*\/code[ \t]*---}m
       COLLAPSE_PATTERN   = %r{^#{OPT_SPACE}---[ \t]*collapse[ \t]*---(.*?)---[ \t]*\/collapse[ \t]*---}m

--- a/lib/kramdown_rpf/kramdown.rb
+++ b/lib/kramdown_rpf/kramdown.rb
@@ -189,6 +189,7 @@ module Kramdown
         @block_parsers.unshift(:task)
       end
 
+
       # Convert Markdown -> :challenge
       # @api private
       def parse_challenge
@@ -271,4 +272,23 @@ module Kramdown
       define_parser(:task, TASK_PATTERN)
     end
   end
+
+  class ParseError < Exception; end
+
+  class Document
+    def to_html
+      output, warnings = Kramdown::Converter::Html.convert(@root, @options)
+      @warnings.concat(warnings)
+      validate!(output)
+    end
+
+    private
+    def validate!(output)
+      keywords = ::Kramdown::Parser::KramdownRPF::KEYWORDS
+      invalid = keywords.select{|keyword| output =~ Regexp.new("—[\s]*#{keyword}[\s]*—")}
+      raise ParseError.new("Markdown contained an unclosed tag: #{invalid}") unless invalid.empty?
+      output
+    end
+  end
+
 end

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -129,13 +129,6 @@ module RPF
         HEREDOC
       end
 
-      def self.markup?(content)
-        keywords = ::Kramdown::Parser::KramdownRPF::KEYWORDS
-        keywords.one?{|keyword|
-          content =~ Regexp.new("—[\s]*#{keyword}[\s]*—")
-        }
-      end
-
     end
   end
 end

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -128,6 +128,14 @@ module RPF
           </div>
         HEREDOC
       end
+
+      def self.markup?(content)
+        keywords = ::Kramdown::Parser::KramdownRPF::KEYWORDS
+        keywords.one?{|keyword|
+          content =~ Regexp.new("—[\s]*#{keyword}[\s]*—")
+        }
+      end
+
     end
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -8,25 +8,26 @@ RSpec.describe KramdownRPF do
   }.freeze
 
   describe "with incomplete markup" do
-    it 'detects bad markup tags' do
+    it 'should raise an exception' do
       I18n.locale = 'en'
       test_result = Kramdown::Document.new(
         File.read("examples/errors/collapse.md"),
         KRAMDOWN_OPTIONS
-      ).to_html
-      expect(RPF::Plugin::Kramdown.markup?(test_result)).to eq(true)
+      )
+
+      expect{ test_result.to_html }.to raise_error(Kramdown::ParseError)
     end
   end
 
   describe "with valid markup" do
-    it 'detects no markup tags' do
+    it 'should not raise any errors' do
       I18n.locale = 'en'
       test_result = Kramdown::Document.new(
         File.read("examples/collapse/collapse.md"),
         KRAMDOWN_OPTIONS
-      ).to_html
+      )
 
-      expect(RPF::Plugin::Kramdown.markup?(test_result)).to eq(false)
+      expect{ test_result.to_html }.not_to raise_error
     end
   end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe KramdownRPF do
+  KRAMDOWN_OPTIONS = {
+    input:              'KramdownRPF',
+    parse_block_html:   true,
+    syntax_highlighter: nil,
+  }.freeze
+
+  describe "with incomplete markup" do
+    it 'detects bad markup tags' do
+      I18n.locale = 'en'
+      test_result = Kramdown::Document.new(
+        File.read("examples/errors/collapse.md"),
+        KRAMDOWN_OPTIONS
+      ).to_html
+      expect(RPF::Plugin::Kramdown.markup?(test_result)).to eq(true)
+    end
+  end
+
+  describe "with valid markup" do
+    it 'detects no markup tags' do
+      I18n.locale = 'en'
+      test_result = Kramdown::Document.new(
+        File.read("examples/collapse/collapse.md"),
+        KRAMDOWN_OPTIONS
+      ).to_html
+
+      expect(RPF::Plugin::Kramdown.markup?(test_result)).to eq(false)
+    end
+  end
+
+end


### PR DESCRIPTION
# what?
to_html raises an exception with a parser error if a markdown keyword is still present in the HTML.

# why?
Prevent bad markup from being processed and passing into systems

# Problems?

It is possible to flag false positives since its a regexp check on the html. 