### PR TITLE
Add page break markup for printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Content inside the following tags will NOT be shown when printed:
   This will not show on screen, only in print
 --- /print-only ---
 
+To add a page break to printed content:
+``` markdown
+First page content
+
+--- new-page ---
+
+Second page content
+```
+
 ### Hints
 
 Within your markdown, add some hints like this:

--- a/README.md
+++ b/README.md
@@ -69,14 +69,18 @@ Content here comes from the ingredient.
 When printing projects, we need to be able to hide that which on a screen would be interactive, and show a print fallback. Similarly we don't want to show the fallback content on screen where the interactive content is available. These two blocks will allow content editors to selectively show or hide content on screens and in print.
 
 Content inside the following tags will NOT be shown when printed:
+``` markdown
 --- no-print ---
   This will not print
 --- /no-print ---
+```
 
 ...and content inside this block will ONLY be shown when printed, not on a screen:
+``` markdown
 --- print-only ---
   This will not show on screen, only in print
 --- /print-only ---
+```
 
 To add a page break to printed content:
 ``` markdown

--- a/examples/new_page/new_page.html
+++ b/examples/new_page/new_page.html
@@ -1,5 +1,5 @@
 <p>First Page</p>
 
-<div class="c-page-break-before"></div>
+<div class="c-print-page-break"></div>
 
 <p>Second Page</p>

--- a/examples/new_page/new_page.html
+++ b/examples/new_page/new_page.html
@@ -1,0 +1,5 @@
+<p>First Page</p>
+
+<div class="c-page-break-before"></div>
+
+<p>Second Page</p>

--- a/examples/new_page/new_page.md
+++ b/examples/new_page/new_page.md
@@ -1,0 +1,5 @@
+First Page
+
+--- new-page ---
+
+Second Page

--- a/kramdown_rpf.gemspec
+++ b/kramdown_rpf.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kramdown', '~> 1.2', '>= 1.2.0'
   spec.add_dependency 'i18n', '0.8.6'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '>= 1.14'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.8.0'

--- a/lib/kramdown_rpf/kramdown.rb
+++ b/lib/kramdown_rpf/kramdown.rb
@@ -34,6 +34,12 @@ module Kramdown
         RPF::Plugin::Kramdown.convert_hints_to_html(el.value)
       end
 
+      # Convert :new_page -> HTML
+      # @api private
+      def convert_new_page(_el, _indent)
+        RPF::Plugin::Kramdown.convert_new_page_to_html
+      end
+
       # Convert :no_print -> HTML
       # @api private
       def convert_no_print(el, _indent)
@@ -85,6 +91,11 @@ module Kramdown
         raise NotImplementedError
       end
 
+      # Convert :new_page-> Markdown (not implemented)
+      def convert_new_page(_el, _opts)
+        raise NotImplementedError
+      end
+
       # Convert :no_print -> Markdown (not implemented)
       def convert_no_print(el, _indent)
         raise NotImplementedError
@@ -131,6 +142,11 @@ module Kramdown
         raise NotImplementedError
       end
 
+      # Convert :new_page -> LaTEX (not implemented)
+      def convert_new_page(_el, _opts)
+        raise NotImplementedError
+      end
+
       # Convert :no_print -> LaTEX (not implemented)
       def convert_no_print(el, _indent)
         raise NotImplementedError
@@ -161,6 +177,7 @@ module Kramdown
         'code',
         'collapse',
         'hints',
+        'new-page',
         'no-print',
         'print-only',
         'save',
@@ -171,6 +188,7 @@ module Kramdown
       COLLAPSE_PATTERN   = %r{^#{OPT_SPACE}---[ \t]*collapse[ \t]*---(.*?)---[ \t]*\/collapse[ \t]*---}m
       HINT_PATTERN       = %r{^#{OPT_SPACE}---[ \t]*hint[ \t]*---(.*?)---[ \t]*\/hint[ \t]*---}m
       HINTS_PATTERN      = %r{^#{OPT_SPACE}---[ \t]*hints[ \t]*---(.*?)---[ \t]*\/hints[ \t]*---}m
+      NEW_PAGE_PATTERN   = %r{^#{OPT_SPACE}---[ \t]*new-page[ \t]*---}m
       NO_PRINT_PATTERN   = %r{^#{OPT_SPACE}---[ \t]*no-print[ \t]*---(.*?)---[ \t]*\/no-print[ \t]*---}m
       PRINT_ONLY_PATTERN = %r{^#{OPT_SPACE}---[ \t]*print-only[ \t]*---(.*?)---[ \t]*\/print-only[ \t]*---}m
       SAVE_PATTERN       = %r{^#{OPT_SPACE}---[ \t]*save[ \t]*---}m
@@ -183,6 +201,7 @@ module Kramdown
         @block_parsers.unshift(:collapse)
         @block_parsers.unshift(:hint)
         @block_parsers.unshift(:hints)
+        @block_parsers.unshift(:new_page)
         @block_parsers.unshift(:no_print)
         @block_parsers.unshift(:print_only)
         @block_parsers.unshift(:save)
@@ -234,6 +253,15 @@ module Kramdown
       end
 
       define_parser(:hints, HINTS_PATTERN)
+
+      # Convert Markdown -> :new_page
+      # @api private
+      def parse_new_page
+        @src.pos += @src.matched_size
+        @tree.children << Element.new(:new_page, @src[1])
+      end
+
+      define_parser(:new_page, NEW_PAGE_PATTERN)
 
       # Convert Markdown -> :no_print
       # @api private

--- a/lib/kramdown_rpf/kramdown.rb
+++ b/lib/kramdown_rpf/kramdown.rb
@@ -111,6 +111,7 @@ module Kramdown
         raise NotImplementedError
       end
 
+      # Convert :task -> Markdown (not implemented)
       def convert_task(_el, _opts)
         raise NotImplementedError
       end

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -99,7 +99,7 @@ module RPF
       end
 
       def self.convert_new_page_to_html
-        ::Kramdown::Document.new("<div class=\"c-page-break-before\" />", KRAMDOWN_OPTIONS).to_html
+        ::Kramdown::Document.new("<div class=\"c-print-page-break\" />", KRAMDOWN_OPTIONS).to_html
       end
 
       def self.convert_no_print_to_html(content)

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -98,6 +98,10 @@ module RPF
         HEREDOC
       end
 
+      def self.convert_new_page_to_html
+        ::Kramdown::Document.new("<div class=\"c-page-break-before\" />", KRAMDOWN_OPTIONS).to_html
+      end
+
       def self.convert_no_print_to_html(content)
         ::Kramdown::Document.new("<div class=\"u-no-print\">\n#{content}</div>", KRAMDOWN_OPTIONS).to_html
       end

--- a/lib/kramdown_rpf/version.rb
+++ b/lib/kramdown_rpf/version.rb
@@ -1,3 +1,3 @@
 module KramdownRPF
-  VERSION = '0.9.3'.freeze
+  VERSION = '0.9.4'.freeze
 end

--- a/spec/kramdown_rpf_spec.rb
+++ b/spec/kramdown_rpf_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe KramdownRPF do
     collapse/collapse_with_space
     hint/hint
     hint/hints
+    new_page/new_page
     no_print/no_print
     print_only/print_only
     save/save


### PR DESCRIPTION
Adds a new markup element - `new-page`. This stands alone and generates a div with a class of `.c-page-break-before`.

This closes #42