### PR TITLE
Try to fix a bug with double parsing ingredients in blocks

### DIFF
--- a/examples/code/code_with_all_features.html
+++ b/examples/code/code_with_all_features.html
@@ -1,4 +1,6 @@
-<p class="c-code-filename">button_press.py</p>
+<div class="c-code-filename">
+  button_press.py
+</div>
 <pre dir="ltr" class="line-numbers" data-start="3" data-line="3, 5-6"><code class="language-python" dir="ltr">
 while True:
     button.wait_for_press()

--- a/examples/code/code_with_all_features.html
+++ b/examples/code/code_with_all_features.html
@@ -1,4 +1,4 @@
-<div class="c-code-filename">button_press.py</div>
+<p class="c-code-filename">button_press.py</p>
 <pre dir="ltr" class="line-numbers" data-start="3" data-line="3, 5-6"><code class="language-python" dir="ltr">
 while True:
     button.wait_for_press()

--- a/examples/code/code_with_filename.html
+++ b/examples/code/code_with_filename.html
@@ -1,4 +1,4 @@
-<div class="c-code-filename">button_press.py</div>
+<p class="c-code-filename">button_press.py</p>
 <pre dir="ltr"><code class="language-python" dir="ltr">
 while True:
     button.wait_for_press()

--- a/examples/code/code_with_filename.html
+++ b/examples/code/code_with_filename.html
@@ -1,4 +1,6 @@
-<p class="c-code-filename">button_press.py</p>
+<div class="c-code-filename">
+  button_press.py
+</div>
 <pre dir="ltr"><code class="language-python" dir="ltr">
 while True:
     button.wait_for_press()

--- a/examples/collapse/collapse_with_code.html
+++ b/examples/collapse/collapse_with_code.html
@@ -1,0 +1,29 @@
+<div class="c-project-panel c-project-panel--ingredient">
+  <h3 class="c-project-panel__heading js-project-panel__toggle">
+    Child project
+  </h3>
+
+  <div class="c-project-panel__content u-hidden">
+    <div class="c-code-filename">
+  <p>main.py</p>
+</div>
+<pre dir="ltr" class="line-numbers" data-start="1" data-line="2"><code class="language-python" dir="ltr">
+vowels = 'AEIOU' # The variable holds a string of vowels
+vowel_list = list(vowels) # Create a list that holds each vowel as a separate item
+print(vowel_list) # Display the list of vowels
+</code></pre>
+
+<p>The output of this code would be:</p>
+
+<pre><code>['A', 'E', 'I', 'O', 'U']
+</code></pre>
+
+  </div>
+</div>
+
+<ol>
+  <li>Now that you know how to get Steve’s position, you can begin your program by storing his poition as three variables. You can use <code>px</code>, <code>py</code>, and <code>pz</code></li>
+</ol>
+
+<pre><code class="language-python">px, py, pz = mc.player.getPos()
+</code></pre>

--- a/examples/collapse/collapse_with_code.md
+++ b/examples/collapse/collapse_with_code.md
@@ -1,0 +1,26 @@
+--- collapse ---
+---
+title: Child project
+---
+<div class="c-code-filename">
+  main.py
+</div>
+<pre dir="ltr" class="line-numbers" data-start="1" data-line="2"><code class="language-python" dir="ltr">
+vowels = 'AEIOU' # The variable holds a string of vowels
+vowel_list = list(vowels) # Create a list that holds each vowel as a separate item
+print(vowel_list) # Display the list of vowels
+</code></pre>
+
+<p>The output of this code would be:</p>
+
+<pre><code>['A', 'E', 'I', 'O', 'U']
+</code></pre>
+
+
+--- /collapse ---
+
+1.  Now that you know how to get Steve's position, you can begin your program by storing his poition as three variables. You can use `px`, `py`, and `pz`
+
+~~~ python
+px, py, pz = mc.player.getPos()
+~~~

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -36,7 +36,7 @@ module RPF
         code              = Regexp.last_match(2)
         pre_attrs         = ['dir="ltr"']
 
-        filename_html = "<div class=\"c-code-filename\">#{filename}</div>" if filename
+        filename_html = "<p class=\"c-code-filename\">#{filename}</p>" if filename
 
         pre_attrs << 'class="line-numbers"' if line_numbers
         pre_attrs << "data-start=\"#{line_number_start}\"" if line_number_start

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -36,7 +36,14 @@ module RPF
         code              = Regexp.last_match(2)
         pre_attrs         = ['dir="ltr"']
 
-        filename_html = "<p class=\"c-code-filename\">#{filename}</p>" if filename
+        if filename
+          filename_html = <<~HEREDOC
+            <div class=\"c-code-filename\">
+              #{filename}
+            </div>
+          HEREDOC
+          .strip
+        end
 
         pre_attrs << 'class="line-numbers"' if line_numbers
         pre_attrs << "data-start=\"#{line_number_start}\"" if line_number_start
@@ -55,6 +62,7 @@ module RPF
         details = YAML.safe_load(Regexp.last_match(1))
         title = details['title']
         content = Regexp.last_match(2)
+
         parsed_content = ::Kramdown::Document.new(content.strip, KRAMDOWN_OPTIONS).to_html
 
         <<~HEREDOC

--- a/spec/kramdown_rpf_spec.rb
+++ b/spec/kramdown_rpf_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe KramdownRPF do
     collapse/collapse
     collapse/collapse_in_challenge
     collapse/collapse_music_box
+    collapse/collapse_with_code
     collapse/collapse_with_space
     hint/hint
     hint/hints


### PR DESCRIPTION
- Kramdown will handle blocks a little strictly where div's are used, e.g.
https://github.com/gettalong/kramdown/blob/master/test/testcases/block/09_html/parse_block_html.html
We had a bug where an ingredient has a code block and when we inject this inside another
project, parsing a second time would escape the closing div in a similar way to the example

Try to fix by indenting and nesting output for code filename so that parsing a second time doesn't escape the div