### PR TITLE
Explicitly add a 'no-line-numbers' class when we don't want line numbers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.3.3
+      - image: cimg/ruby:2.3.3
         environment:
           RAILS_ENV: test
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.3.3
+      - image: cimg/ruby:2.7.2
         environment:
           RAILS_ENV: test
     steps:

--- a/examples/code/code_with_no_line_numbers.html
+++ b/examples/code/code_with_no_line_numbers.html
@@ -1,0 +1,7 @@
+<pre dir="ltr" class="no-line-numbers" data-start="3"><code class="language-python" dir="ltr">
+while True:
+    button.wait_for_press()
+    parp = random.choice(trumps)
+    os.system(&quot;aplay {0}&quot;.format(parp))
+    sleep(2)
+</code></pre>

--- a/examples/code/code_with_no_line_numbers.md
+++ b/examples/code/code_with_no_line_numbers.md
@@ -1,0 +1,12 @@
+--- code ---
+---
+language: python
+line_numbers: false
+line_number_start: 3
+---
+while True:
+    button.wait_for_press()
+    parp = random.choice(trumps)
+    os.system("aplay {0}".format(parp))
+    sleep(2)
+--- /code ---

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -30,7 +30,7 @@ module RPF
         language          = meta['language']
         filename          = meta['filename'] || nil
         filename_html     = nil
-        line_numbers      = meta['line_numbers'] || false
+        line_numbers      = meta['line_numbers']
         line_number_start = meta['line_number_start'] || nil
         line_highlights   = meta['line_highlights'] || nil
         code              = CGI.escapeHTML(Regexp.last_match(2))
@@ -45,7 +45,11 @@ module RPF
           .strip
         end
 
-        pre_attrs << 'class="line-numbers"' if line_numbers
+        if line_numbers
+          pre_attrs << 'class="line-numbers"'
+        elsif line_numbers == false
+          pre_attrs << 'class="no-line-numbers"'
+        end
         pre_attrs << "data-start=\"#{line_number_start}\"" if line_number_start
         pre_attrs << "data-line=\"#{line_highlights}\"" if line_highlights
 

--- a/spec/kramdown_rpf_spec.rb
+++ b/spec/kramdown_rpf_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe KramdownRPF do
     code/code_with_angle_brackets
     code/code_with_filename
     code/code_with_line_numbers
+    code/code_with_no_line_numbers
     code/code_with_line_highlights
     collapse/collapse
     collapse/collapse_in_challenge


### PR DESCRIPTION
https://github.com/RaspberryPiFoundation/projects-ui/issues/1994

https://github.com/PrismJS/prism/issues/3561

Seems to be a conflict between 2 plugins in Prism JS

Line Highlight: https://prismjs.com/plugins/line-highlight/ Line Numbers: https://prismjs.com/plugins/line-numbers/

The former seems to assume line numbers are being used unless the class is specifically applied to the <pre> Try to alleviate by making Kramdown apply the no-line-numbers class when we don't want them - we have to explicitly set line_numbers to false in the markdown - to avoid breaking everything.