### PR TITLE
When line highlighting is used, the attribute is data-line-offset not data-start

### DIFF
--- a/examples/code/code_with_all_features.html
+++ b/examples/code/code_with_all_features.html
@@ -1,7 +1,7 @@
 <div class="c-code-filename">
   button_press.py
 </div>
-<pre dir="ltr" class="line-numbers" data-start="3" data-line="3, 5-6"><code class="language-python" dir="ltr">
+<pre dir="ltr" class="line-numbers" data-start="3" data-line-offset="3" data-line="3, 5-6"><code class="language-python" dir="ltr">
 while True:
     button.wait_for_press()
     parp = random.choice(trumps)

--- a/examples/code/code_with_angle_brackets.html
+++ b/examples/code/code_with_angle_brackets.html
@@ -1,7 +1,7 @@
 <div class="c-code-filename">
   StarController.cs - OnTriggerEnter(Collider other)
 </div>
-<pre dir="ltr" class="line-numbers" data-start="21" data-line="26, 27"><code class="language-cs" dir="ltr">
+<pre dir="ltr" class="line-numbers" data-start="21" data-line-offset="21" data-line="26, 27"><code class="language-cs" dir="ltr">
     void OnTriggerEnter(Collider other)
     {
         // Check the tag of the colliding object

--- a/examples/code/code_with_no_line_numbers.html
+++ b/examples/code/code_with_no_line_numbers.html
@@ -1,4 +1,4 @@
-<pre dir="ltr" class="no-line-numbers" data-start="3"><code class="language-python" dir="ltr">
+<pre dir="ltr" class="no-line-numbers"><code class="language-python" dir="ltr">
 while True:
     button.wait_for_press()
     parp = random.choice(trumps)

--- a/examples/code/code_with_no_line_numbers.md
+++ b/examples/code/code_with_no_line_numbers.md
@@ -2,7 +2,6 @@
 ---
 language: python
 line_numbers: false
-line_number_start: 3
 ---
 while True:
     button.wait_for_press()

--- a/lib/kramdown_rpf/rpf.rb
+++ b/lib/kramdown_rpf/rpf.rb
@@ -50,7 +50,8 @@ module RPF
         elsif line_numbers == false
           pre_attrs << 'class="no-line-numbers"'
         end
-        pre_attrs << "data-start=\"#{line_number_start}\"" if line_number_start
+        pre_attrs << "data-start=\"#{line_number_start}\"" if line_number_start && line_numbers
+        pre_attrs << "data-line-offset=\"#{line_number_start}\"" if line_highlights && line_number_start
         pre_attrs << "data-line=\"#{line_highlights}\"" if line_highlights
 
         pre_attrs_html = ' ' + pre_attrs.join(' ') if pre_attrs.size.positive?

--- a/lib/kramdown_rpf/version.rb
+++ b/lib/kramdown_rpf/version.rb
@@ -1,3 +1,3 @@
 module KramdownRPF
-  VERSION = '0.11.4'.freeze
+  VERSION = '0.11.5'.freeze
 end


### PR DESCRIPTION
Related to: https://github.com/RaspberryPiFoundation/projects-ui/issues/1994

https://prismjs.com/plugins/line-highlight/ vs https://prismjs.com/plugins/line-numbers/

- ensure that when an offset is specified with line highlighting, the attribute is added
- bump version because we will anyway